### PR TITLE
fix: preserve original case when undoing standalone ư with ww

### DIFF
--- a/vnkey-engine/src/engine.rs
+++ b/vnkey-engine/src/engine.rs
@@ -1530,10 +1530,13 @@ impl Engine {
                 || self.buf(self.current).key_code == b'W' as u32)
         {
             // ww → hoàn tác ư thành w (chỉ 1 ký tự w, không append thêm)
+            // Giữ nguyên case gốc: ư→w, Ư→W (không phụ thuộc phím thứ 2)
+            let original_caps = self.buf(self.current).caps;
             self.mark_change(self.current);
             self.buffer[self.current as usize].form = WordForm::NonVn;
             self.buffer[self.current as usize].vn_sym = VnLexiName::NonVnChar;
-            self.buffer[self.current as usize].key_code = b'w' as u32;
+            self.buffer[self.current as usize].key_code = if original_caps { b'W' as u32 } else { b'w' as u32 };
+            self.buffer[self.current as usize].v_offset = -1;
             self.single_mode = false;
             self.reverted = true;
             return true;

--- a/vnkey-engine/tests/integration.rs
+++ b/vnkey-engine/tests/integration.rs
@@ -6,7 +6,6 @@ mod tests {
     /// Helper: feed a string of ASCII keys and return the UTF-8 output
     fn type_word(engine: &mut Engine, keys: &str) -> String {
         engine.reset();
-        let mut result = String::new();
         let mut total_output = Vec::<u8>::new();
 
         for ch in keys.bytes() {
@@ -28,8 +27,7 @@ mod tests {
                 total_output.push(ch);
             }
         }
-        result = String::from_utf8_lossy(&total_output).to_string();
-        result
+        String::from_utf8_lossy(&total_output).to_string()
     }
 
     #[test]
@@ -148,10 +146,54 @@ mod tests {
         let mut engine = Engine::new();
         engine.set_input_method(InputMethod::Telex);
 
-        // 'w' alone should produce 'w', not 'ư'
-        assert_eq!(type_word(&mut engine, "w"), "w");
-        // 'ww' should produce 'ww'
-        assert_eq!(type_word(&mut engine, "ww"), "ww");
+        // 'w' alone produces standalone 'ư'
+        assert_eq!(type_word(&mut engine, "w"), "ư");
+        // 'ww' undoes ư back to 'w'
+        assert_eq!(type_word(&mut engine, "ww"), "w");
+        // 'W' alone produces standalone 'Ư'
+        assert_eq!(type_word(&mut engine, "W"), "Ư");
+        // 'WW' undoes Ư back to 'W'
+        assert_eq!(type_word(&mut engine, "WW"), "W");
+
+        // Mixed-case undo: phải giữ case gốc, không phụ thuộc phím thứ 2
+        // ư (từ w) + W (undo) → w (giữ lowercase gốc)
+        assert_eq!(type_word(&mut engine, "wW"), "w");
+        // Ư (từ W) + w (undo) → W (giữ uppercase gốc)
+        assert_eq!(type_word(&mut engine, "Ww"), "W");
+    }
+
+    #[test]
+    fn test_telex_ww_then_continue_typing() {
+        let mut engine = Engine::new();
+        engine.set_input_method(InputMethod::Telex);
+
+        // Sau khi ww → w, gõ tiếp ký tự thường phải nối đúng
+        assert_eq!(type_word(&mut engine, "wwa"), "wa");
+        assert_eq!(type_word(&mut engine, "wwin"), "win");
+        assert_eq!(type_word(&mut engine, "wwe"), "we");
+
+        // Sau khi ww → w, gõ tiếp từ tiếng Việt mới
+        assert_eq!(type_word(&mut engine, "ww anw"), "w ăn");
+        assert_eq!(type_word(&mut engine, "ww dda"), "w đa");
+        assert_eq!(type_word(&mut engine, "ww ees"), "w ế");
+    }
+
+    #[test]
+    fn test_telex_w_consecutive() {
+        let mut engine = Engine::new();
+        engine.set_input_method(InputMethod::Telex);
+
+        // w lặp lại: ww undo về w, www = w + ư mới, wwww undo ww, ...
+        assert_eq!(type_word(&mut engine, "ww"), "w");
+        assert_eq!(type_word(&mut engine, "www"), "wư");
+        assert_eq!(type_word(&mut engine, "wwww"), "ww");
+        assert_eq!(type_word(&mut engine, "wwwww"), "wwư");
+        assert_eq!(type_word(&mut engine, "wwwwww"), "www");
+
+        // Tương tự với W hoa
+        assert_eq!(type_word(&mut engine, "WW"), "W");
+        assert_eq!(type_word(&mut engine, "WWW"), "WƯ");
+        assert_eq!(type_word(&mut engine, "WWWW"), "WW");
     }
 
     #[test]


### PR DESCRIPTION
## Vấn đề

Test `test_telex_w_standalone` trên master expect `w` → `w` và `ww` → `ww`, nhưng engine thực tế output `w` → `ư` và `ww` → `w` (Telex chuẩn). Ngoài ra phát hiện 2 bug khi undo `ww`.

## Bug phát hiện

### 1. Mất case gốc khi undo `WW`

Engine hardcode `b'w' as u32` nên `WW` trả về `w` thay vì `W`, `wW` trả về `W` thay vì `w`.

| Input | Kỳ vọng | Trước fix |
|-------|---------|----------|
| `ww` | `w` | `w` ✓ |
| `WW` | `W` | `w` ❌ |
| `wW` | `w` | `W` ❌ |
| `Ww` | `W` | `w` ❌ |

### 2. `v_offset` không reset khi undo → `www` ra `ow` thay vì `wư`

Khi tạo standalone `ư`, engine đặt `v_offset = 0`. Undo `ww` chỉ đổi `form` thành `NonVn` nhưng không reset `v_offset`. Phím `w` thứ 3 thấy `v_offset >= 0` → tưởng có nguyên âm để móc → hook sai thành `o`.

| Input | Kỳ vọng | Trước fix |
|-------|---------|----------|
| `www` | `wư` | `ow` ❌ |
| `wwww` | `ww` | `owư` ❌ |
| `wwwww` | `wwư` | `oww` ❌ |

## Thay đổi

**engine.rs**:
- Dùng `self.buf(self.current).caps` để giữ case gốc khi undo
- Thêm `v_offset = -1` khi undo để ngăn hook sai

```rust
let original_caps = self.buf(self.current).caps;
self.buffer[...].key_code = if original_caps { b'W' as u32 } else { b'w' as u32 };
self.buffer[...].v_offset = -1;
```

**tests/integration.rs**:
- Cập nhật assertion `w`/`ww` cho đúng engine behavior
- `test_telex_w_standalone`: thêm W/WW, mixed-case undo (wW, Ww)
- `test_telex_ww_then_continue_typing`: gõ tiếp sau ww (wwa, wwin, ww anw...)
- `test_telex_w_consecutive`: w lặp (ww, www, wwww, wwwww, wwwwww) + W hoa

## Kết quả

35/35 tests passed, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Telex input method handling for the `w`/`W` keys, implementing undo semantics where consecutive key presses properly collapse to their base characters while preserving case.
  * Improved behavior for Vietnamese text input when using repeated `w` key sequences.

* **Tests**
  * Added comprehensive test coverage for Telex `w`/`W` key behavior, including mixed-case undo scenarios and consecutive key sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->