### PR TITLE
fix: WW mất case gốc, www bị móc sai, và wswa bị auto-restore nhảy phím thô

### DIFF
--- a/vnkey-engine/src/engine.rs
+++ b/vnkey-engine/src/engine.rs
@@ -1530,10 +1530,14 @@ impl Engine {
                 || self.buf(self.current).key_code == b'W' as u32)
         {
             // ww → hoàn tác ư thành w (chỉ 1 ký tự w, không append thêm)
+            // Giữ nguyên case gốc: ư→w, Ư→W (không phụ thuộc phím thứ 2)
+            let original_caps = self.buf(self.current).caps;
             self.mark_change(self.current);
             self.buffer[self.current as usize].form = WordForm::NonVn;
             self.buffer[self.current as usize].vn_sym = VnLexiName::NonVnChar;
-            self.buffer[self.current as usize].key_code = b'w' as u32;
+            self.buffer[self.current as usize].key_code = if original_caps { b'W' as u32 } else { b'w' as u32 };
+            self.buffer[self.current as usize].v_offset = -1;
+            self.buffer[self.current as usize].tone = 0;
             self.single_mode = false;
             self.reverted = true;
             return true;

--- a/vnkey-engine/tests/integration.rs
+++ b/vnkey-engine/tests/integration.rs
@@ -6,7 +6,6 @@ mod tests {
     /// Helper: feed a string of ASCII keys and return the UTF-8 output
     fn type_word(engine: &mut Engine, keys: &str) -> String {
         engine.reset();
-        let mut result = String::new();
         let mut total_output = Vec::<u8>::new();
 
         for ch in keys.bytes() {
@@ -28,8 +27,7 @@ mod tests {
                 total_output.push(ch);
             }
         }
-        result = String::from_utf8_lossy(&total_output).to_string();
-        result
+        String::from_utf8_lossy(&total_output).to_string()
     }
 
     #[test]
@@ -148,10 +146,69 @@ mod tests {
         let mut engine = Engine::new();
         engine.set_input_method(InputMethod::Telex);
 
-        // 'w' alone should produce 'w', not 'ư'
-        assert_eq!(type_word(&mut engine, "w"), "w");
-        // 'ww' should produce 'ww'
-        assert_eq!(type_word(&mut engine, "ww"), "ww");
+        // 'w' alone produces standalone 'ư'
+        assert_eq!(type_word(&mut engine, "w"), "ư");
+        // 'ww' undoes ư back to 'w'
+        assert_eq!(type_word(&mut engine, "ww"), "w");
+        // 'W' alone produces standalone 'Ư'
+        assert_eq!(type_word(&mut engine, "W"), "Ư");
+        // 'WW' undoes Ư back to 'W'
+        assert_eq!(type_word(&mut engine, "WW"), "W");
+
+        // Mixed-case undo: phải giữ case gốc, không phụ thuộc phím thứ 2
+        // ư (từ w) + W (undo) → w (giữ lowercase gốc)
+        assert_eq!(type_word(&mut engine, "wW"), "w");
+        // Ư (từ W) + w (undo) → W (giữ uppercase gốc)
+        assert_eq!(type_word(&mut engine, "Ww"), "W");
+    }
+
+    #[test]
+    fn test_telex_ww_then_continue_typing() {
+        let mut engine = Engine::new();
+        engine.set_input_method(InputMethod::Telex);
+
+        // Sau khi ww → w, gõ tiếp ký tự thường phải nối đúng
+        assert_eq!(type_word(&mut engine, "wwa"), "wa");
+        assert_eq!(type_word(&mut engine, "wwin"), "win");
+        assert_eq!(type_word(&mut engine, "wwe"), "we");
+
+        // Sau khi ww → w, gõ tiếp từ tiếng Việt mới
+        assert_eq!(type_word(&mut engine, "ww anw"), "w ăn");
+        assert_eq!(type_word(&mut engine, "ww dda"), "w đa");
+        assert_eq!(type_word(&mut engine, "ww ees"), "w ế");
+    }
+
+    #[test]
+    fn test_telex_w_consecutive() {
+        let mut engine = Engine::new();
+        engine.set_input_method(InputMethod::Telex);
+
+        // w lặp lại: ww undo về w, www = w + ư mới, wwww undo ww, ...
+        assert_eq!(type_word(&mut engine, "ww"), "w");
+        assert_eq!(type_word(&mut engine, "www"), "wư");
+        assert_eq!(type_word(&mut engine, "wwww"), "ww");
+        assert_eq!(type_word(&mut engine, "wwwww"), "wwư");
+        assert_eq!(type_word(&mut engine, "wwwwww"), "www");
+
+        // Tương tự với W hoa
+        assert_eq!(type_word(&mut engine, "WW"), "W");
+        assert_eq!(type_word(&mut engine, "WWW"), "WƯ");
+        assert_eq!(type_word(&mut engine, "WWWW"), "WW");
+    }
+
+    #[test]
+    fn test_telex_w_undo_with_tone() {
+        let mut engine = Engine::new();
+        engine.set_input_method(InputMethod::Telex);
+
+        // ứ (ws) + w (undo) → w, tone phải reset để không gây auto-restore sai
+        assert_eq!(type_word(&mut engine, "wsw"), "w");
+        // ừ (wf) + ww → wư
+        assert_eq!(type_word(&mut engine, "wfww"), "wư");
+        // ử (wr) + ww → wư
+        assert_eq!(type_word(&mut engine, "wrww"), "wư");
+        // ứ + wa → wa (auto-restore không bị nhảy, tone đã reset)
+        assert_eq!(type_word(&mut engine, "wswa"), "wa");
     }
 
     #[test]


### PR DESCRIPTION
Tiếp nối PR #7 (đã close). PR #7 đã xử lý `ww` → `w` cơ bản, nhưng upstream master vẫn còn 3 bug chưa fix.

## Bug còn lại trên master

### 1. `WW` mất case gốc → luôn ra `w`

Dòng `self.buffer[...].key_code = b'w' as u32` hardcode lowercase:

| Input | Kỳ vọng | Master hiện tại |
|-------|---------|------------------|
| `WW` | `W` | `w` ❌ |
| `wW` | `w` | `W` ❌ |
| `Ww` | `W` | `w` ❌ |

### 2. `www` bị móc sai thành `ow` do `v_offset` không reset

Khi tạo standalone `ư`, engine đặt `v_offset = 0`. Undo `ww` đổi `form` thành `NonVn` nhưng không reset `v_offset`. Phím `w` thứ 3 thấy `v_offset >= 0` → tưởng có nguyên âm để móc → hook sai thành `o`.

| Input | Kỳ vọng | Master hiện tại |
|-------|---------|------------------|
| `www` | `wư` | `ow` ❌ |
| `wwww` | `ww` | `owư` ❌ |
| `wwwww` | `wwư` | `oww` ❌ |

### 3. `wswa` bị auto-restore nhảy phím thô do `tone` không reset

Khi undo `ứ` (ư+sắc) về `w`, `tone` vẫn giữ giá trị `1`. Hàm `try_auto_restore` coi `tone != 0` là có modification tiếng Việt → restore toàn bộ phím Telex thô.

```
w → ư, s → ứ, w (undo) → w [tone=1 còn sót], a → auto-restore kick in → "wswa" ❌
```

| Input | Kỳ vọng | Master hiện tại |
|-------|---------|------------------|
| `wsw` | `w` | `w` ✓ |
| `wswa` | `wa` | `wswa` ❌ |
| `wfww` | `wư` | `wư` ✓ |

## Thay đổi

**engine.rs** — block undo `ww` trong `process_telex_w`, reset đủ các trường:

```rust
let original_caps = self.buf(self.current).caps;
self.buffer[...].form = WordForm::NonVn;
self.buffer[...].vn_sym = VnLexiName::NonVnChar;
self.buffer[...].key_code = if original_caps { b'W' as u32 } else { b'w' as u32 };
self.buffer[...].v_offset = -1;  // fix bug #2: ngăn hook sai
self.buffer[...].tone = 0;       // fix bug #3: ngăn auto-restore nhảy
```

**tests/integration.rs** — 4 test mới:
- `test_telex_w_standalone`: cập nhật assertion + thêm W/WW, mixed-case undo
- `test_telex_ww_then_continue_typing`: gõ tiếp sau ww
- `test_telex_w_consecutive`: w lặp (ww, www, wwww, ...)
- `test_telex_w_undo_with_tone`: undo khi có dấu (wsw, wfww, wswa)

## Kết quả

36/36 tests passed, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Telex undo for 'w'/'W': creating 'ư'/'Ư' and reverting with 'ww'/'WW' now preserves original case and resets tone/vowel alignment so the undo result is tone-free.

* **Tests**
  * Added and expanded integration tests covering consecutive 'w' sequences, mixed-case undo behavior, and continued typing after undo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->