### PR TITLE
ci: add AUR publishing workflow for fcitx5 and ibus packages

### DIFF
--- a/.github/aur/fcitx5-vnkey-bin/PKGBUILD
+++ b/.github/aur/fcitx5-vnkey-bin/PKGBUILD
@@ -1,0 +1,18 @@
+# Maintainer: Bixa <datvu310594 at gmail.com>
+# Maintainer: Thien An Dang Thanh <24854119+thienandangthanh at users.noreply.github.com>
+
+pkgname=fcitx5-vnkey-bin
+pkgver=PLACEHOLDER_VER
+pkgrel=1
+pkgdesc="Vietnamese IME for Fcitx5"
+arch=('x86_64')
+url="https://github.com/marixdev/vnkey"
+license=('GPL')
+depends=('fcitx5')
+source=("$pkgname-$pkgver.pkg.tar.zst::https://github.com/marixdev/vnkey/releases/download/v$pkgver/vnkey-fcitx5-v$pkgver-1-x86_64.pkg.tar.zst")
+sha256sums=('PLACEHOLDER_SHA256')
+
+package() {
+    cp -a "$srcdir/." "$pkgdir/"
+    rm -rf "$pkgdir/.PKGINFO" "$pkgdir/.BUILDINFO" "$pkgdir/.MTREE" "$pkgdir/.INSTALL" 2>/dev/null || true
+}

--- a/.github/aur/ibus-vnkey-bin/PKGBUILD
+++ b/.github/aur/ibus-vnkey-bin/PKGBUILD
@@ -1,0 +1,18 @@
+# Maintainer: Bixa <datvu310594 at gmail.com>
+# Maintainer: Thien An Dang Thanh <24854119+thienandangthanh at users.noreply.github.com>
+
+pkgname=ibus-vnkey-bin
+pkgver=PLACEHOLDER_VER
+pkgrel=1
+pkgdesc="Vietnamese IME for IBus"
+arch=('x86_64')
+url="https://github.com/marixdev/vnkey"
+license=('GPL')
+depends=('ibus')
+source=("$pkgname-$pkgver.pkg.tar.zst::https://github.com/marixdev/vnkey/releases/download/v$pkgver/vnkey-ibus-v$pkgver-1-x86_64.pkg.tar.zst")
+sha256sums=('PLACEHOLDER_SHA256')
+
+package() {
+    cp -a "$srcdir/." "$pkgdir/"
+    rm -rf "$pkgdir/.PKGINFO" "$pkgdir/.BUILDINFO" "$pkgdir/.MTREE" "$pkgdir/.INSTALL" 2>/dev/null || true
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -556,7 +556,7 @@ jobs:
           - pkgname: ibus-vnkey-bin
             artifact_prefix: vnkey-ibus
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Extract pkgver and SHA256 from release
         id: meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,7 +564,7 @@ jobs:
           PKGVER="${GITHUB_REF_NAME#v}"
           ARTIFACT_FILE="${{ matrix.artifact_prefix }}-v${PKGVER}-1-x86_64.pkg.tar.zst"
           SHA256=$(curl -fsSL \
-            "https://github.com/marixdev/vnkey/releases/download/v${PKGVER}/SHA256SUMS.txt" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/v${PKGVER}/SHA256SUMS.txt" \
             | grep "${ARTIFACT_FILE}" | awk '{print $1}')
           if [ -z "$SHA256" ]; then
             echo "::error::Failed to extract SHA256 for ${ARTIFACT_FILE}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,3 +541,52 @@ jobs:
         with:
           files: release/*
           body_path: /tmp/release_body.md
+
+  # ===== Publish to AUR =====
+  aur-publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkgname: fcitx5-vnkey-bin
+            artifact_prefix: vnkey-fcitx5
+          - pkgname: ibus-vnkey-bin
+            artifact_prefix: vnkey-ibus
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract pkgver and SHA256 from release
+        id: meta
+        run: |
+          PKGVER="${GITHUB_REF_NAME#v}"
+          ARTIFACT_FILE="${{ matrix.artifact_prefix }}-v${PKGVER}-1-x86_64.pkg.tar.zst"
+          SHA256=$(curl -fsSL \
+            "https://github.com/marixdev/vnkey/releases/download/v${PKGVER}/SHA256SUMS.txt" \
+            | grep "${ARTIFACT_FILE}" | awk '{print $1}')
+          if [ -z "$SHA256" ]; then
+            echo "::error::Failed to extract SHA256 for ${ARTIFACT_FILE}"
+            exit 1
+          fi
+          echo "pkgver=$PKGVER" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Patch PKGBUILD
+        run: |
+          cp .github/aur/${{ matrix.pkgname }}/PKGBUILD ./PKGBUILD
+          sed -i "s/PLACEHOLDER_VER/${{ steps.meta.outputs.pkgver }}/g" PKGBUILD
+          sed -i "s/PLACEHOLDER_SHA256/${{ steps.meta.outputs.sha256 }}/g" PKGBUILD
+          cat PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        with:
+          pkgname: ${{ matrix.pkgname }}
+          pkgbuild: ./PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ steps.meta.outputs.pkgver }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ sudo dpkg -i vnkey-fcitx5_1.0.1_amd64.deb
 sudo dnf install ./vnkey-fcitx5-1.0.1-1.x86_64.rpm
 
 # Arch Linux
-sudo pacman -U vnkey-fcitx5-1.0.1-1-x86_64.pkg.tar.zst
+paru -S fcitx5-vnkey-bin
+# hoặc
+yay -S fcitx5-vnkey-bin
 ```
 
 #### NixOS (Fcitx5)
@@ -110,7 +112,9 @@ sudo dpkg -i vnkey-ibus_1.0.1_amd64.deb
 sudo dnf install ./vnkey-ibus-1.0.1-1.x86_64.rpm
 
 # Arch Linux
-sudo pacman -U vnkey-ibus-1.0.1-1-x86_64.pkg.tar.zst
+paru -S ibus-vnkey-bin
+# hoặc
+yay -S ibus-vnkey-bin
 ```
 
 #### NixOS (IBus)


### PR DESCRIPTION
  ## Mô tả
  PR này thêm tính năng tự động phát hành (publish) các gói cài đặt cho Arch Linux lên AUR (Arch User Repository) và cập nhật tài liệu hướng dẫn cài đặt tương ứng.
  Chi tiết các thay đổi:
  - **CI/CD**: Thêm workflow GitHub Actions để tự động cập nhật và đẩy các gói [`fcitx5-vnkey-bin`](https://aur.archlinux.org/packages/fcitx5-vnkey-bin) và [`ibus-vnkey-bin`](https://aur.archlinux.org/packages/ibus-vnkey-bin) lên AUR mỗi khi có release mới (kích hoạt khi có tag `v*`).
  - **AUR Packages**: Tạo các file template `PKGBUILD` chuẩn cho cả hai biến thể Fcitx5 và IBus.
  - **Tài liệu**: Cập nhật `README.md`, thay đổi hướng dẫn cài đặt thủ công bằng `pacman -U` sang sử dụng các AUR helper phổ biến ([`paru`](https://github.com/Morganamilo/paru) / [`yay`](https://github.com/Jguer/yay)), giúp đơn giản hóa quá trình cài đặt cho người dùng Arch Linux.

**⚠️ Lưu ý quan trọng về GitHub Actions:**
  Để workflow hoạt động như mong đợi, cần phải thêm 3 Repository secrets sau tại trang [`Settings -> Secrets and variables -> Actions -> New repository
  secret`](https://github.com/marixdev/vnkey/settings/secrets/actions):
  - `AUR_USERNAME`
  - `AUR_EMAIL`
  - `AUR_SSH_PRIVATE_KEY`

  ## Loại thay đổi
  - [ ] Bug fix
  - [ ] Tính năng mới
  - [ ] Refactor / cải thiện code
  - [x] Tài liệu
  - [x] CI workflow

  ## Nền tảng ảnh hưởng
  - [ ] Engine (ảnh hưởng tất cả)
  - [ ] Windows
  - [ ] macOS
  - [ ] Linux (Fcitx5)
  - [ ] Linux (IBus)

  ## Kiểm tra
  - [x] `cargo test` pass trong `vnkey-engine`
  - [x] Đã test thủ công trên nền tảng liên quan
  - [x] Đã test trigger workflow trên fork https://github.com/thienandangthanh/vnkey
    - [x] release v1.0.3c https://github.com/thienandangthanh/vnkey/releases/tag/v1.0.3c
    - [x] kết quả workflow https://github.com/thienandangthanh/vnkey/actions/runs/23905885404
    - [x] kết quả commit trên AUR
      - fcitx5 - https://aur.archlinux.org/cgit/aur.git/commit/?h=fcitx5-vnkey-bin&id=707f31ffe31f64cd295c529764a4d084b63f5536
      - ibus - https://aur.archlinux.org/cgit/aur.git/commit/?h=ibus-vnkey-bin&id=0be31e87c8d73224ee692221e199f533a866c2c2
  ## Issue liên quan
  ## Nguồn tham khảo
- [Using secrets in GitHub Actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets)
- [AUR Submission Guideline - Authentication](https://wiki.archlinux.org/title/AUR_submission_guidelines#Authentication)
- [KSXGitHub/github-actions-deploy-aur](https://github.com/KSXGitHub/github-actions-deploy-aur/blob/2ac5a4c1d7035885d46b10e3193393be8460b6f1/README.md)
  <!-- Closes #... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Arch Linux AUR packages for fcitx5-vnkey-bin and ibus-vnkey-bin to simplify installation on Arch-based systems.
  * Added automated AUR publishing to the release workflow to publish package updates on versioned releases.

* **Documentation**
  * Updated installation instructions to recommend installing the new AUR packages via common AUR helpers (e.g., paru/yay).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->